### PR TITLE
validate_kafka use stdout instead of output

### DIFF
--- a/start.py
+++ b/start.py
@@ -46,7 +46,7 @@ def validate_kafka(node, broker_count, quiet):
     if command.exit_code != 0:
         return False
 
-    nodes = command.output
+    nodes = command.stdout
     if not nodes.startswith('['):
         return False
 


### PR DESCRIPTION
In the new versions of Kafka, from 3.0 onwards, the new zookeper version combines stderr and stdout. This change causes the validate_kafka function to fail to parse the output because it contains a java error. Thanks to the latest cluserdock [change](https://github.com/clusterdock/clusterdock/commit/8785bf38fa1f9d424487fbba7e81ab806e8c3b30), we have the option to separate stderr and stdout.